### PR TITLE
add cargo deny

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,11 @@ defaults:
   run:
     working-directory: gql2sql_node
 jobs:
+  cargo-deny:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: EmbarkStudios/cargo-deny-action@v1
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/cache_tags/Cargo.toml
+++ b/cache_tags/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cache_tags"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,282 @@
+# This template contains all of the possible sections and their default values
+
+# Note that all fields that take a lint level have these possible values:
+# * deny - An error will be produced and the check will fail
+# * warn - A warning will be produced, but the check will not fail
+# * allow - No warning or error will be produced, though in some cases a note
+# will be
+
+# The values provided in this template are the default values that will be used
+# when any section or field is not specified in your own configuration
+
+# Root options
+
+# If 1 or more target triples (and optionally, target_features) are specified,
+# only the specified targets will be checked when running `cargo deny check`.
+# This means, if a particular package is only ever used as a target specific
+# dependency, such as, for example, the `nix` crate only being used via the
+# `target_family = "unix"` configuration, that only having windows targets in
+# this list would mean the nix crate, as well as any of its exclusive
+# dependencies not shared by any other crates, would be ignored, as the target
+# list here is effectively saying which targets you are building for.
+targets = [
+    # The triple can be any string, but only the target triples built in to
+    # rustc (as of 1.40) can be checked against actual config expressions
+    #{ triple = "x86_64-unknown-linux-musl" },
+    # You can also specify which target_features you promise are enabled for a
+    # particular target. target_features are currently not validated against
+    # the actual valid features supported by the target architecture.
+    #{ triple = "wasm32-unknown-unknown", features = ["atomics"] },
+]
+# When creating the dependency graph used as the source of truth when checks are
+# executed, this field can be used to prune crates from the graph, removing them
+# from the view of cargo-deny. This is an extremely heavy hammer, as if a crate
+# is pruned from the graph, all of its dependencies will also be pruned unless
+# they are connected to another crate in the graph that hasn't been pruned,
+# so it should be used with care. The identifiers are [Package ID Specifications]
+# (https://doc.rust-lang.org/cargo/reference/pkgid-spec.html)
+#exclude = []
+# If true, metadata will be collected with `--all-features`. Note that this can't
+# be toggled off if true, if you want to conditionally enable `--all-features` it
+# is recommended to pass `--all-features` on the cmd line instead
+all-features = false
+# If true, metadata will be collected with `--no-default-features`. The same
+# caveat with `all-features` applies
+no-default-features = false
+# If set, these feature will be enabled when collecting metadata. If `--features`
+# is specified on the cmd line they will take precedence over this option.
+#features = []
+# When outputting inclusion graphs in diagnostics that include features, this
+# option can be used to specify the depth at which feature edges will be added.
+# This option is included since the graphs can be quite large and the addition
+# of features from the crate(s) to all of the graph roots can be far too verbose.
+# This option can be overridden via `--feature-depth` on the cmd line
+feature-depth = 1
+
+# This section is considered when running `cargo deny check advisories`
+# More documentation for the advisories section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
+[advisories]
+# The path where the advisory database is cloned/fetched into
+db-path = "~/.cargo/advisory-db"
+# The url(s) of the advisory databases to use
+db-urls = ["https://github.com/rustsec/advisory-db"]
+# The lint level for security vulnerabilities
+vulnerability = "deny"
+# The lint level for unmaintained crates
+unmaintained = "warn"
+# The lint level for crates that have been yanked from their source registry
+yanked = "warn"
+# The lint level for crates with security notices. Note that as of
+# 2019-12-17 there are no security notice advisories in
+# https://github.com/rustsec/advisory-db
+notice = "warn"
+# A list of advisory IDs to ignore. Note that ignored advisories will still
+# output a note when they are encountered.
+ignore = [
+    #"RUSTSEC-0000-0000",
+]
+# Threshold for security vulnerabilities, any vulnerability with a CVSS score
+# lower than the range specified will be ignored. Note that ignored advisories
+# will still output a note when they are encountered.
+# * None - CVSS Score 0.0
+# * Low - CVSS Score 0.1 - 3.9
+# * Medium - CVSS Score 4.0 - 6.9
+# * High - CVSS Score 7.0 - 8.9
+# * Critical - CVSS Score 9.0 - 10.0
+#severity-threshold =
+
+# If this is true, then cargo deny will use the git executable to fetch advisory database.
+# If this is false, then it uses a built-in git library.
+# Setting this to true can be helpful if you have special authentication requirements that cargo-deny does not support.
+# See Git Authentication for more information about setting up git authentication.
+#git-fetch-with-cli = true
+
+# This section is considered when running `cargo deny check licenses`
+# More documentation for the licenses section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
+[licenses]
+# The lint level for crates which do not have a detectable license
+unlicensed = "deny"
+# List of explicitly allowed licenses
+# See https://spdx.org/licenses/ for list of possible licenses
+# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "ISC",
+    "Unicode-DFS-2016",
+    "BSD-3-Clause",
+    "MPL-2.0",
+    "OpenSSL",
+    "BSD-2-Clause",
+    "Apache-2.0 WITH LLVM-exception",
+]
+# List of explicitly disallowed licenses
+# See https://spdx.org/licenses/ for list of possible licenses
+# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
+deny = [
+    #"Nokia",
+]
+# Lint level for licenses considered copyleft
+copyleft = "warn"
+# Blanket approval or denial for OSI-approved or FSF Free/Libre licenses
+# * both - The license will be approved if it is both OSI-approved *AND* FSF
+# * either - The license will be approved if it is either OSI-approved *OR* FSF
+# * osi-only - The license will be approved if is OSI-approved *AND NOT* FSF
+# * fsf-only - The license will be approved if is FSF *AND NOT* OSI-approved
+# * neither - This predicate is ignored and the default lint level is used
+allow-osi-fsf-free = "neither"
+# Lint level used when no other predicates are matched
+# 1. License isn't in the allow or deny lists
+# 2. License isn't copyleft
+# 3. License isn't OSI/FSF, or allow-osi-fsf-free = "neither"
+default = "deny"
+# The confidence threshold for detecting a license from license text.
+# The higher the value, the more closely the license text must be to the
+# canonical license text of a valid SPDX license file.
+# [possible values: any between 0.0 and 1.0].
+confidence-threshold = 0.8
+# Allow 1 or more licenses on a per-crate basis, so that particular licenses
+# aren't accepted for every possible crate as with the normal allow list
+exceptions = [
+    # Each entry is the crate and version constraint, and its specific allow
+    # list
+    # { allow = ["gql2sql"], name = "gql2sql", version = "*" },
+    # { allow = ["gql2sql_deno"], name = "gql2sql", version = "*" },
+    # { allow = ["gql2sql_lambda"], name = "gql2sql", version = "*" },
+    # { allow = ["gql2sql_node"], name = "gql2sql", version = "*" },
+    # { allow = ["gql2sql_server"], name = "gql2sql", version = "*" },
+    # { allow = ["gql2sql_wasm"], name = "gql2sql", version = "*" },
+    # { allow = ["gql2sql_worker"], name = "gql2sql", version = "*" },
+
+]
+
+# Some crates don't have (easily) machine readable licensing information,
+# adding a clarification entry for it allows you to manually specify the
+# licensing information
+[[licenses.clarify]]
+# The name of the crate the clarification applies to
+name = "ring"
+# The optional version constraint for the crate
+version = "*"
+# The SPDX expression for the license requirements of the crate
+expression = "MIT AND ISC AND OpenSSL"
+# One or more files in the crate's source used as the "source of truth" for
+# the license expression. If the contents match, the clarification will be used
+# when running the license check, otherwise the clarification will be ignored
+# and the crate will be checked normally, which may produce warnings or errors
+# depending on the rest of your configuration
+license-files = [
+    # Each entry is a crate relative path, and the (opaque) hash of its contents
+    #{ path = "LICENSE", hash = 0xbd0eed23 }
+]
+
+[licenses.private]
+# If true, ignores workspace crates that aren't published, or are only
+# published to private registries.
+# To see how to mark a crate as unpublished (to the official registry),
+# visit https://doc.rust-lang.org/cargo/reference/manifest.html#the-publish-field.
+ignore = true
+# One or more private registries that you might publish crates to, if a crate
+# is only published to private registries, and ignore is true, the crate will
+# not have its license(s) checked
+registries = [
+    #"https://sekretz.com/registry
+]
+
+# This section is considered when running `cargo deny check bans`.
+# More documentation about the 'bans' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
+[bans]
+# Lint level for when multiple versions of the same crate are detected
+multiple-versions = "allow"
+# Lint level for when a crate version requirement is `*`
+wildcards = "allow"
+# The graph highlighting used when creating dotgraphs for crates
+# with multiple versions
+# * lowest-version - The path to the lowest versioned duplicate is highlighted
+# * simplest-path - The path to the version with the fewest edges is highlighted
+# * all - Both lowest-version and simplest-path are used
+highlight = "all"
+# The default lint level for `default` features for crates that are members of
+# the workspace that is being checked. This can be overriden by allowing/denying
+# `default` on a crate-by-crate basis if desired.
+workspace-default-features = "allow"
+# The default lint level for `default` features for external crates that are not
+# members of the workspace. This can be overriden by allowing/denying `default`
+# on a crate-by-crate basis if desired.
+external-default-features = "allow"
+# List of crates that are allowed. Use with care!
+allow = [
+    #{ name = "ansi_term", version = "=0.11.0" },
+]
+# List of crates to deny
+deny = [
+    # Each entry the name of a crate and a version range. If version is
+    # not specified, all versions will be matched.
+    #{ name = "ansi_term", version = "=0.11.0" },
+    #
+    # Wrapper crates can optionally be specified to allow the crate when it
+    # is a direct dependency of the otherwise banned crate
+    #{ name = "ansi_term", version = "=0.11.0", wrappers = [] },
+]
+
+# List of features to allow/deny
+# Each entry the name of a crate and a version range. If version is
+# not specified, all versions will be matched.
+#[[bans.features]]
+#name = "reqwest"
+# Features to not allow
+#deny = ["json"]
+# Features to allow
+#allow = [
+#    "rustls",
+#    "__rustls",
+#    "__tls",
+#    "hyper-rustls",
+#    "rustls",
+#    "rustls-pemfile",
+#    "rustls-tls-webpki-roots",
+#    "tokio-rustls",
+#    "webpki-roots",
+#]
+# If true, the allowed features must exactly match the enabled feature set. If
+# this is set there is no point setting `deny`
+#exact = true
+
+# Certain crates/versions that will be skipped when doing duplicate detection.
+skip = [
+    #{ name = "ansi_term", version = "=0.11.0" },
+]
+# Similarly to `skip` allows you to skip certain crates during duplicate
+# detection. Unlike skip, it also includes the entire tree of transitive
+# dependencies starting at the specified crate, up to a certain depth, which is
+# by default infinite.
+skip-tree = [
+    #{ name = "ansi_term", version = "=0.11.0", depth = 20 },
+]
+
+# This section is considered when running `cargo deny check sources`.
+# More documentation about the 'sources' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/sources/cfg.html
+[sources]
+# Lint level for what to happen when a crate from a crate registry that is not
+# in the allow list is encountered
+unknown-registry = "warn"
+# Lint level for what to happen when a crate from a git repository that is not
+# in the allow list is encountered
+unknown-git = "warn"
+# List of URLs for allowed crate registries. Defaults to the crates.io index
+# if not specified. If it is specified but empty, no registries are allowed.
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+# List of URLs for allowed Git repositories
+allow-git = []
+
+[sources.allow-org]
+# 1 or more github.com organizations to allow git sources for
+# github = [""]
+# 1 or more gitlab.com organizations to allow git sources for
+# gitlab = [""]
+# 1 or more bitbucket.org organizations to allow git sources for
+# bitbucket = [""]

--- a/gql2sql/Cargo.toml
+++ b/gql2sql/Cargo.toml
@@ -7,7 +7,6 @@ publish = false
 [dependencies]
 anyhow = "1.0"
 graphql-parser = "0.4"
-serde_json = "1.0"
 sqlparser = "0.30"
 
 [dev-dependencies]

--- a/gql2sql/Cargo.toml
+++ b/gql2sql/Cargo.toml
@@ -2,6 +2,7 @@
 name = "gql2sql"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 anyhow = "1.0"

--- a/gql2sql_deno/Cargo.toml
+++ b/gql2sql_deno/Cargo.toml
@@ -14,4 +14,3 @@ gql2sql = { path = "../gql2sql" }
 graphql-parser = "0.4"
 deno_bindgen = "0.7.0"
 serde = { version = "1", features = ["derive"] }
-cached = "0.42.0"

--- a/gql2sql_deno/Cargo.toml
+++ b/gql2sql_deno/Cargo.toml
@@ -2,6 +2,7 @@
 name = "gql2sql_deno"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [lib]
 name = "gql2sql"

--- a/gql2sql_lambda/Cargo.toml
+++ b/gql2sql_lambda/Cargo.toml
@@ -2,6 +2,7 @@
 name = "gql2sql_lambda"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 # Starting in Rust 1.62 you can use `cargo add` to add dependencies
 # to your project.

--- a/gql2sql_node/Cargo.toml
+++ b/gql2sql_node/Cargo.toml
@@ -3,6 +3,7 @@ authors = ["LongYinan <lynweklm@gmail.com>"]
 edition = "2021"
 name = "gql2sql_node"
 version = "0.1.0"
+publish = false
 
 [lib]
 crate-type = ["cdylib"]

--- a/gql2sql_server/Cargo.toml
+++ b/gql2sql_server/Cargo.toml
@@ -2,6 +2,7 @@
 name = "gql2sql_server"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/gql2sql_server/Cargo.toml
+++ b/gql2sql_server/Cargo.toml
@@ -8,20 +8,16 @@ publish = false
 
 [dependencies]
 gql2sql = { path = "../gql2sql" }
-actix-web = "4.3.0"
-json = "0.12.4"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.93", features = ["raw_value"] }
 graphql-parser = "0.4.0"
-dotenv = "0.15.0"
-dotenv_codegen = "0.15.0"
-futures = "0.3.26"
 jemallocator = "0.5.0"
-axum = { version = "0.6.7", features = ["headers"] }
+axum = { version = "0.6.9", features = ["headers"] }
 tokio = { version = "1.25", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 sqlx = { version = "0.6", features = ["runtime-tokio-rustls", "any", "postgres"] }
 tower-http = { version = "0.3.5", features = ["compression-br", "compression-gzip", "propagate-header", "sensitive-headers", "set-header", "trace", "validate-request", "auth"] }
 http = "0.2.9"
+dotenvy = "0.15.6"
 

--- a/gql2sql_server/src/main.rs
+++ b/gql2sql_server/src/main.rs
@@ -1,8 +1,6 @@
 #[global_allocator]
 static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
-extern crate dotenv;
-
 use axum::{
     async_trait,
     extract::{FromRef, FromRequestParts, State},
@@ -11,7 +9,7 @@ use axum::{
     routing::post,
     Json, Router,
 };
-use dotenv::dotenv;
+use dotenvy::dotenv;
 use http::{
     header::{HeaderName, AUTHORIZATION},
     HeaderValue,

--- a/gql2sql_wasm/Cargo.toml
+++ b/gql2sql_wasm/Cargo.toml
@@ -2,6 +2,7 @@
 name = "gql2sql_wasm"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/gql2sql_wasm/Cargo.toml
+++ b/gql2sql_wasm/Cargo.toml
@@ -11,17 +11,8 @@ crate-type = ["cdylib", "rlib"]
 console_error_panic_hook = { version = "0.1.7", optional = true }
 gql2sql = { path = "../gql2sql" }
 graphql-parser = "0.4.0"
-js-sys = "0.3.61"
 serde = { version = "1.0", features = ["derive"] }
-serde-wasm-bindgen = "0.4"
 wasm-bindgen = "0.2.84"
-wee_alloc = "0.4.5"
-
-[dependencies.web-sys]
-version = "0.3"
-features = [
-  "console",
-]
 
 [profile.release]
 lto = true

--- a/gql2sql_worker/Cargo.toml
+++ b/gql2sql_worker/Cargo.toml
@@ -2,6 +2,7 @@
 name = "gql2sql-worker"
 version = "0.0.0"
 edition = "2018"
+publish = false
 
 [lib]
 crate-type = ["cdylib", "rlib"]


### PR DESCRIPTION
Cargo Deny is a sweet little cli tool that finds issues with your dependencies and lets you know when there's something bad. It imports a simple config file that allows you to set what is okay and what is not okay with your dependencies. It's widely used in the Rust community.

I've also added a job in the lint Github Action.

Here is the repo that explains more about it.

https://github.com/EmbarkStudios/cargo-deny 

To install it you run

```
cargo install --locked cargo-deny
```

To run cargo deny

```
cargo deny check
```